### PR TITLE
Distinguish between encoding with and without padding, add z-base-32.

### DIFF
--- a/multibase.csv
+++ b/multibase.csv
@@ -2,11 +2,16 @@ encoding,     code, name
 base1,        1,    unary tends to be 11111
 base2,        0,    binary has 1 and 0
 base8,        7,    highest char in octal
-base10,        9,    highest char in decimal
+base10,       9,    highest char in decimal
 base16,       Ff,   highest char in hex
-base32,       Uu,   rfc4648 - highest letter
-base32hex,    Vv,   rfc4648 - highest char
-base58flickr, Z,    highest char
-base58btc,    z,    highest char
-base64,       y,    rfc4648 highest char
-base64url,    Y,    rfc4648 highest char
+base32hex,    Vv,   rfc4648 no padding - highest char
+base32hexpad, Tt,   rfc4648 with padding
+base32,       Bb,   rfc4648 no padding
+base32pad,    Cc,   rfc4648 with padding
+base32z       h,    z-base-32 - used by Tahoe-LAFS - highest letter
+base58flickr, Z,    highest letter
+base58btc,    z,    highest letter
+base64,       m,    rfc4648 no padding
+base64pad,    M,    rfc4648 with padding - MIME encoding
+base64url,    u,    rfc4648 no padding
+base64urlpad, U,    rfc4648 with padding


### PR DESCRIPTION
See #9.  

'H' really is the highest letter use in base32z due to the reordering alphabet it used.

No reason behind the 'B' and 'C' other than there are easy to remember (for me) and I figured we might want to reserve 'A'.

Not sure what we should do about the names.  If we are going to give everything separate names we might also want to distinguish between the upper and lower case versions of base16 and base32.
