### PR TITLE
Added identity encoding as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The current multibase table is [here](multibase.csv):
 
 ```
 encoding      codes   name
+identity      0x00    8-bit binary (encoder and decoder keeps data unmodified)
 base1         1       unary tends to be 11111
 base2         0       binary has 1 and 0
 base8         7       highest char in octal
@@ -50,7 +51,6 @@ These encodings are being considered:
 
 ```
 base128
-base256ascii  X       ascii
 base-emoji    😎      base emoji
 base65536     ᔰ       base65536
 utf8

--- a/multibase.csv
+++ b/multibase.csv
@@ -1,4 +1,5 @@
 encoding,     code, name
+identity,     0x00, 8-bit binary (encoder and decoder keeps data unmodified)
 base1,        1,    unary tends to be 11111
 base2,        0,    binary has 1 and 0
 base8,        7,    highest char in octal


### PR DESCRIPTION
8-bit clean channels do not need a base conversion, therefore it saves both bandwidth and performance if the data is simply not transformed. "ascii" as a name would be confusing, because many developers outside the US use that as a synonym for 7-bit clean channels. Personally I do not see a big reason to use base-1 and base-2 encodings in practice, so I am not worried about confusing binary with base-2.