### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ base64url,          u,    rfc4648 no padding
 base64urlpad,       U,    rfc4648 with padding
 ```
 
-These encodings are being considered:
-
-```
-base128
-base-emoji    😎      base emoji
-base65536     ᔰ       base65536
-utf8
-utf16
-```
-
 ## Multibase By Example
 
 Consider the following encodings of the same binary string:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ base64url,          u,    rfc4648 no padding
 base64urlpad,       U,    rfc4648 with padding
 ```
 
+**NOTE:** Multibase-prefixes are encoding agnostic. "z" is "z", not 0x7a ("z" encoded as ASCII/UTF-8). For example, in UTF-32, "z" would be `[0x7a, 0x00, 0x00, 0x00]`.
+
 ## Multibase By Example
 
 Consider the following encodings of the same binary string:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ can usually infer the encoding from the context.
 However, when bytes are encoded as text (using a base encoding), the base choice
 of base encoding is often restricted by the context. Worse, these restrictions
 can change based on where the data appears in the text. In some cases, we can
-only use `[a-z0-9]`. In others, we can use a larger set of symbols but need a
+only use `[a-z0-9]`. In others, we can use a larger set of characters but need a
 compact encoding. This has lead to a large set of "base encodings", one for
 every use-case. Unlike when encoding text to bytes, we can't just standardize
 around a single base encoding because there is no optimal encoding for all
@@ -45,10 +45,10 @@ multibase comes in. It answers the question:
 The Format is:
 
 ```
-<base-encoding-symbol><base-encoded-data>
+<base-encoding-character><base-encoded-data>
 ```
 
-Where `<base-encoding-symbol>` is used according to the multibase table.
+Where `<base-encoding-character>` is used according to the multibase table.
 
 ### Multibase Table v1.0.0-RC (semver)
 
@@ -116,7 +116,7 @@ Yes. If i give you `"1214314321432165"` is that decimal? or hex? or something el
 
 > Why the strange selection of codes / characters?
 
-The code values are selected such that they are included in the alphabets of the base they represent. For example, `F` is the base code for `base16 (hex)`, because `F` is in hex's 16 character alphabet. Note that the alphabets can be encoded in ASCII or UTF8. We have not found a case needing something else.
+The code values are selected such that they are included in the alphabets of the base they represent. For example, `f` is the base code for `base16 (hex)`, because `f` is in hex's 16 character alphabet. Note that the alphabets can be encoded in ASCII or UTF8. We have not found a case needing something else.
 
 > Don't we have to agree on a table of base encodings?
 
@@ -140,7 +140,7 @@ Yes, but we already have to agree on base encodings, so this is not hard. The ta
 
 ## Disclaimers
 
-Warning: **obviously multibase changes the first symbol depending on the encoding**. Do not expect the value to be exactly the same. Remove the multibase prefix before using the value.
+Warning: **obviously multibase changes the first character depending on the encoding**. Do not expect the value to be exactly the same. Remove the multibase prefix before using the value.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Base encodings exist because transports have restrictions, use special in-band s
 The Format is:
 
 ```
-<varint-base-encoding-code><base-encoded-data>
+<base-encoding-symbol><base-encoded-data>
 ```
 
-Where `<varint-base-encoding-code>` is used according to the multibase table. Note that varints (bases above 127) are not yet supported, but planned.
+Where `<base-encoding-symbol>` is used according to the multibase table.
 
 ### Multibase Table v1.0.0-RC (semver)
 
@@ -111,14 +111,6 @@ Yes. If i give you `"1214314321432165"` is that decimal? or hex? or something el
 
 The code values are selected such that they are included in the alphabets of the base they represent. For example, `F` is the base code for `base16 (hex)`, because `F` is in hex's 16 character alphabet. Note that the alphabets here are ASCII or UTF8 compliant. We have not found a case needing something else.
 
-> Why varints?
-
-So that we have no limitation on functions or lengths. Implementation note: you do not need to implement varints until the standard multibase table has more than 127 functions.
-
-> What kind of varints?
-
-An Most Significant Bit unsigned varint, as defined by the [multiformats/unsigned-varint](https://github.com/multiformats/unsigned-varint).
-
 > Don't we have to agree on a table of base encodings?
 
 Yes, but we already have to agree on base encodings, so this is not hard. The table even leaves some room for custom encodings.
@@ -141,7 +133,7 @@ Yes, but we already have to agree on base encodings, so this is not hard. The ta
 
 ## Disclaimers
 
-Warning: **obviously multibase changes the first byte(s) depending on the encoding**. Do not expect the value to be exactly the same. Remove the multibase prefix before using the value.
+Warning: **obviously multibase changes the first symbol depending on the encoding**. Do not expect the value to be exactly the same. Remove the multibase prefix before using the value.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 > Self identifying base encodings
 
-Multibase is a protocol for distinguishing base encodings of bytes in text.
+Multibase is a protocol for disambiguating the encoding of base-encoded (e.g.,
+base32, base64, base58, etc.) binary appearing in text.
 
 When text is encoded as bytes, we can usually use a one-size-fits-all encoding
 (UTF-8) because we're always encoding to the same set of 256 bytes (+/- the NUL

--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@
 
 > Self identifying base encodings
 
-Multibase is a protocol for distinguishing base encodings and other simple string encodings, and for ensuring full compatibility with program interfaces. It answers the question:
+Multibase is a protocol for distinguishing base encodings of bytes in text.
 
-> Given data d encoded into string s, how can I tell what base d is encoded with?
+When text is encoded as bytes, we can usually use a one-size-fits-all encoding
+(UTF-8) because we're always encoding to the same set of 256 bytes (+/- the NUL
+byte). When that doesn't work, usually for historical or performance reasons, we
+can usually infer the encoding from the context.
 
-Base encodings exist because transports have restrictions, use special in-band sequences, or must be human-friendly. When systems chose a base to use, it is not always clear _which_ base to use, as there are many tradeoffs in the decision. Multibase is here to save programs and programmers from worrying about which encoding is best. It solves the biggest problem: a program can use multibase to take input or produce output in whichever base is desired. The important part is that the value is self-describing, letting other programs elsewhere know what encoding it is using.
+However, when bytes are encoded as text (using a base encoding), the base choice
+of base encoding is often restricted by the context. Worse, these restrictions
+can change based on where the data appears in the text. In some cases, we can
+only use `[a-z0-9]`. In others, we can use a larger set of symbols but need a
+compact encoding. This has lead to a large set of "base encodings", one for
+every use-case. Unlike when encoding text to bytes, we can't just standardize
+around a single base encoding because there is no optimal encoding for all
+cases.
+
+Unfortunately, it's not always clear *what* base encoding is used; that's where
+multibase comes in. It answers the question:
+
+> Given data d encoded into text s, what base is it encoded with?
 
 ## Table of Contents
 
@@ -109,7 +124,7 @@ Yes. If i give you `"1214314321432165"` is that decimal? or hex? or something el
 
 > Why the strange selection of codes / characters?
 
-The code values are selected such that they are included in the alphabets of the base they represent. For example, `F` is the base code for `base16 (hex)`, because `F` is in hex's 16 character alphabet. Note that the alphabets here are ASCII or UTF8 compliant. We have not found a case needing something else.
+The code values are selected such that they are included in the alphabets of the base they represent. For example, `F` is the base code for `base16 (hex)`, because `F` is in hex's 16 character alphabet. Note that the alphabets can be encoded in ASCII or UTF8. We have not found a case needing something else.
 
 > Don't we have to agree on a table of base encodings?
 


### PR DESCRIPTION
* Remove mentions of varints. Multibase prefixes are *text symbols*.
* Explain the problem multibase is trying to solve (and relate it to the inverse problem: utf8, ascii, etc.).
* misc cleanups.