### PR TITLE
Remove Base1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The current multibase table is [here](multibase.csv):
 ```
 encoding,           code, description
 identity,           0x00, 8-bit binary (encoder and decoder keeps data unmodified)
-base1,              1,    unary (11111)
 base2,              0,    binary (01010101)
 base8,              7,    octal
 base10,             9,    decimal

--- a/multibase.csv
+++ b/multibase.csv
@@ -1,6 +1,5 @@
 encoding,           code, description
 identity,           0x00, 8-bit binary (encoder and decoder keeps data unmodified)
-base1,              1,    unary (11111)
 base2,              0,    binary (01010101)
 base8,              7,    octal
 base10,             9,    decimal


### PR DESCRIPTION
Base1 takes roughly 255 times more space than the Byte Array it would be representing; it is both computationally and space inefficient and isn't used.