### PR TITLE
remove base1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The current multibase table is [here](multibase.csv):
 ```
 encoding,           code, description
 identity,           0x00, 8-bit binary (encoder and decoder keeps data unmodified)
-base1,              1,    unary (11111)
 base2,              0,    binary (01010101)
 base8,              7,    octal
 base10,             9,    decimal

--- a/multibase.csv
+++ b/multibase.csv
@@ -1,6 +1,5 @@
 encoding,           code, description
 identity,           0x00, 8-bit binary (encoder and decoder keeps data unmodified)
-base1,              1,    unary (11111)
 base2,              0,    binary (01010101)
 base8,              7,    octal
 base10,             9,    decimal


### PR DESCRIPTION
1. It's not used anywhere.
2. It's absolutely useless.
3. It's making our lives harder in libp2p (inline peer IDs currently start with 1).