### PR TITLE
Chore/declare 1 and q as reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ base32z,           h,    z-base-32 (used by Tahoe-LAFS),                        
 base36,            k,    base36 [0-9a-z] case-insensitive - no padding,            draft
 base36upper,       K,    base36 [0-9a-z] case-insensitive - no padding,            draft
 base58btc,         z,    base58 bitcoin,                                           default
-base58flickr,      Z,    base58 flicker,                                           candidate
+base58flickr,      Z,    base58 flickr,                                            candidate
 base64,            m,    rfc4648 no padding,                                       default
 base64pad,         M,    rfc4648 with padding - MIME encoding,                     candidate
 base64url,         u,    rfc4648 no padding,                                       default

--- a/multibase.csv
+++ b/multibase.csv
@@ -22,3 +22,5 @@ base64,            m,    rfc4648 no padding,                                    
 base64pad,         M,    rfc4648 with padding - MIME encoding,                     candidate
 base64url,         u,    rfc4648 no padding,                                       default
 base64urlpad,      U,    rfc4648 with padding,                                     default
+legacyreserved1,   1,    legacy reserved code - NO IMPLEMENTATIONS,                invalid
+legacyreservedqm,  Q,    legacy reserved code - NO IMPLEMENTATIONS,                invalid

--- a/multibase.csv
+++ b/multibase.csv
@@ -17,7 +17,7 @@ base32z,           h,    z-base-32 (used by Tahoe-LAFS),                        
 base36,            k,    base36 [0-9a-z] case-insensitive - no padding,            draft
 base36upper,       K,    base36 [0-9a-z] case-insensitive - no padding,            draft
 base58btc,         z,    base58 bitcoin,                                           default
-base58flickr,      Z,    base58 flicker,                                           candidate
+base58flickr,      Z,    base58 flickr,                                            candidate
 base64,            m,    rfc4648 no padding,                                       default
 base64pad,         M,    rfc4648 with padding - MIME encoding,                     candidate
 base64url,         u,    rfc4648 no padding,                                       default


### PR DESCRIPTION
We do clarify that `1` and `Q` are off limits, but there's no machine-parseable variant of the same. 