### PR TITLE
Add description for test vectors

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+Multibase test vectors
+======================
+
+This directory contains test vectors that should be used by every implementation to check if it correctly implements the Base encoding as specified by Multibase.
+
+| Filename | String to encode | Description
+| -------- | ---------------- | -----------
+| `test1.csv` | `Decentralize everything!!` | Non alphanumeric characters
+| `test2.csv` | `yes mani !` | Non alphanumeric characters
+| `test3.csv` | `hello world` | ASCII letters only
+| `test4.csv` | `\x00yes mani !` | Leading zero byte
+| `test5.csv` | `\x00\x00yes mani !` | Two leading zero bytes
+| `test6.csv` | `hello world` | Differently cased than expected, must decode without errors


### PR DESCRIPTION
I was looking at the test vectors (in order to add them to the Rust implementation). I think test vectors should always serve a purpose, hence I documented them in this README.

Though I couldn't make sense for all of them. Some seem to test exactly the same thing. Hence I propose removing some. I propose removing `test2.csv`, `test3.csv`, `test4.csv` as I don't see how they add value.