### PR TITLE
feat: add proquint

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ base64,            m,    rfc4648 no padding,                                    
 base64pad,         M,    rfc4648 with padding - MIME encoding,                     candidate
 base64url,         u,    rfc4648 no padding,                                       default
 base64urlpad,      U,    rfc4648 with padding,                                     default
+proquint,          p,    PRO-QUINT https://arxiv.org/html/0901.4016,               draft
 ```
 
 **NOTE:** Multibase-prefixes are encoding agnostic. "z" is "z", not 0x7a ("z" encoded as ASCII/UTF-8). For example, in UTF-32, "z" would be `[0x7a, 0x00, 0x00, 0x00]`.

--- a/multibase.csv
+++ b/multibase.csv
@@ -22,3 +22,4 @@ base64,            m,    rfc4648 no padding,                                    
 base64pad,         M,    rfc4648 with padding - MIME encoding,                     candidate
 base64url,         u,    rfc4648 no padding,                                       default
 base64urlpad,      U,    rfc4648 with padding,                                     default
+proquint,          p,    PRO-QUINT https://arxiv.org/html/0901.4016,               draft

--- a/rfcs/PRO-QUINT.md
+++ b/rfcs/PRO-QUINT.md
@@ -1,0 +1,7 @@
+# PRO-QUINT
+
+See: https://arxiv.org/html/0901.4016 ([/ipfs/bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa](https://bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa.ipfs.dweb.link)).
+
+While the multibase prefix is `q`, the "full" prefix is actually `pro-`. This way, proquints are always easily pronouncable. For example
+
+`127.0.0.1`, as a multibase proquint encoded number, is `pro-lusab-babad`.

--- a/rfcs/PRO-QUINT.md
+++ b/rfcs/PRO-QUINT.md
@@ -2,6 +2,6 @@
 
 See: https://arxiv.org/html/0901.4016 ([/ipfs/bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa](https://bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa.ipfs.dweb.link)).
 
-While the multibase prefix is `q`, the "full" prefix is actually `pro-`. This way, proquints are always easily pronouncable. For example
+While the multibase prefix is `p`, the "full" prefix is actually `pro-`. This way, proquints are always easily pronouncable. For example
 
 `127.0.0.1`, as a multibase proquint encoded number, is `pro-lusab-babad`.

--- a/rfcs/PRO-QUINT.md
+++ b/rfcs/PRO-QUINT.md
@@ -1,6 +1,6 @@
 # PRO-QUINT
 
-See: https://arxiv.org/html/0901.4016 ([/ipfs/bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa](https://bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa.ipfs.dweb.link)).
+See: https://arxiv.org/html/0901.4016 ([/ipfs/bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa](https://dweb.link/ipfs/bafybeib5jsyi5igjwhi7hzkfebpvnq2ykbwpxeaaxlkyfyxqvcecoao4qa)).
 
 While the multibase prefix is `p`, the "full" prefix is actually `pro-`. This way, proquints are always easily pronouncable. For example
 


### PR DESCRIPTION
We're removing proquint support from IPNS and making it a multibase. I've chosen `p` or "pro-" so proquints are always fully pronounceable.