### PR TITLE
Improve consistancy of some base codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The current multibase table is [here](multibase.csv):
 ```
 encoding,          code, description,                                                  status
 identity,          0x00, 8-bit binary (encoder and decoder keeps data unmodified),     default
-base2,             0,    binary (01010101),                                            candidate
+base2,             1,    binary (01010101),                                            candidate
 base8,             7,    octal,                                                        draft
 base10,            9,    decimal,                                                      draft
 base16,            f,    hexadecimal,                                                  default

--- a/multibase.csv
+++ b/multibase.csv
@@ -1,6 +1,6 @@
 encoding,          code, description,                                                  status
 identity,          0x00, 8-bit binary (encoder and decoder keeps data unmodified),     default
-base2,             0,    binary (01010101),                                            candidate
+base2,             1,    binary (01010101),                                            candidate
 base8,             7,    octal,                                                        draft
 base10,            9,    decimal,                                                      draft
 base16,            f,    hexadecimal,                                                  default


### PR DESCRIPTION
I know that many of you will go wild when seeing this pull request, but I think it could be useful. Also, I dare to do it, because `base2` is a `candidate` and not a `default`.

The reason for this change is simple:
 - Base 2 (binary), having the digits `0` and `1`. Taking the highest to use as code, `1`. This is not the case, so lets change it.
 - Base 8 (octal), having the digits `0`, `1`, `2`, `3`, `4`, `5`, `6` and `7`. Taking the higest, `7` to use as code. This is already the case.
 - Base 10 (decimal), having the digits `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8` and `9`. Taking the higest, `9` to use as code. This is already the case.
 - Base 16 (hexadecimal), having the alphanumerals `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `9`, `A`, `B`, `C`, `D`, `E` and `F`. Taking the higest, `F` to use as code. This is already the case. Same for lowercase.

If people disagree on **changing** it, we can also **add** a new record for `1` to use as code. Eventually, we later decide if we drop code `0` or give it another purpose. (For example, unary. I like that one.)