### PR TITLE
add mf/mf/discussions link to issue homepage and make `registration_announce` issue more actionable

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW-REGISTRATION.yml
+++ b/.github/ISSUE_TEMPLATE/NEW-REGISTRATION.yml
@@ -16,7 +16,7 @@ body:
   - type: checkboxes
     attributes:
       label: "Have read contributing"
-      description: I have read the [contributing](https://github.com/multiformats/multiformats/blob/master/contributing.md) document
+      description: I have read the [contributing](https://github.com/multiformats/multiformats/blob/master/contributing.md) document, including the policies about deprecating stale, incomplete, or unimplemented/underutilized registrations
       options:
       - label: I read it!
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Protocol Labs Vulnerability Disclosure Team
     url: mailto:security@ipfs.io
     about: Please do NOT open issues related to security of implementations or spec here without contacting the IPFS security team first.
+  - name: Multiformats Repo Discussions
+    url: https://github.com/multiformats/multiformats/discussions
+    about: If you'd like to discuss an implementation of multibase you're working on, please use the discussions section on the core multiformats repo instead of this one.


### PR DESCRIPTION
As discussed in #109 . Don't merge until discussions are turned on for Multiformats/multiformats, tho!