### PR TITLE
Add Base45 (RFC9285) to Multibase table

### DIFF
--- a/multibase.csv
+++ b/multibase.csv
@@ -17,6 +17,7 @@ U+0043,     C,          base32padupper,     RFC4648 case-insensitive - with padd
 U+0068,     h,          base32z,            z-base-32 (used by Tahoe-LAFS),                                 draft
 U+006b,     k,          base36,             Base36 [0-9a-z] case-insensitive - no padding,                  draft
 U+004b,     K,          base36upper,        Base36 [0-9a-z] case-insensitive - no padding,                  draft
+U+0071,     q,          base45,             Base45 RFC9285                                                  draft
 U+007a,     z,          base58btc,          Base58 Bitcoin,                                                 final
 U+005a,     Z,          base58flickr,       Base58 Flicker,                                                 experimental
 U+006d,     m,          base64,             RFC4648 no padding,                                             final

--- a/multibase.csv
+++ b/multibase.csv
@@ -17,7 +17,7 @@ U+0043,     C,          base32padupper,     RFC4648 case-insensitive - with padd
 U+0068,     h,          base32z,            z-base-32 (used by Tahoe-LAFS),                                 draft
 U+006b,     k,          base36,             Base36 [0-9a-z] case-insensitive - no padding,                  draft
 U+004b,     K,          base36upper,        Base36 [0-9a-z] case-insensitive - no padding,                  draft
-U+0071,     q,          base45,             Base45 RFC9285                                                  draft
+U+0052,     R,          base45,             Base45 RFC9285                                                  draft
 U+007a,     z,          base58btc,          Base58 Bitcoin,                                                 final
 U+005a,     Z,          base58flickr,       Base58 Flicker,                                                 experimental
 U+006d,     m,          base64,             RFC4648 no padding,                                             final

--- a/multibase.csv
+++ b/multibase.csv
@@ -17,7 +17,7 @@ U+0043,     C,          base32padupper,     RFC4648 case-insensitive - with padd
 U+0068,     h,          base32z,            z-base-32 (used by Tahoe-LAFS),                                 draft
 U+006b,     k,          base36,             Base36 [0-9a-z] case-insensitive - no padding,                  draft
 U+004b,     K,          base36upper,        Base36 [0-9a-z] case-insensitive - no padding,                  draft
-U+0052,     R,          base45,             Base45 RFC9285                                                  draft
+U+0052,     R,          base45,             Base45 RFC9285,                                                 draft
 U+007a,     z,          base58btc,          Base58 Bitcoin,                                                 final
 U+005a,     Z,          base58flickr,       Base58 Flicker,                                                 experimental
 U+006d,     m,          base64,             RFC4648 no padding,                                             final


### PR DESCRIPTION
This PR adds support for Base45 encoding ([RFC9285](https://datatracker.ietf.org/doc/html/rfc9285)), which is useful when encoding characters that will be placed into a QR Code. QR Codes have an optimized ALPHANUMERIC format that uses base45 encoding.